### PR TITLE
Add default color palette variable

### DIFF
--- a/src/styles/uswds-application-ui/_settings.scss
+++ b/src/styles/uswds-application-ui/_settings.scss
@@ -83,6 +83,15 @@ $theme-line-height-scale: (
   none:  1     // line-height-none utility
 );
 
+// Initialize the color palette map so it's defined before use
+$theme-color-palette: (
+  gray: (),
+  red: (),
+  indigo: (),
+  orange: (),
+  green: ()
+) !default;
+
 // grayscale brand palette (derived from USWDS gray tokens)
 $theme-color-base-lightest: map-get(map-get($theme-color-palette, gray), 5);
 $theme-color-base-light:   map-get(map-get($theme-color-palette, gray), 10);


### PR DESCRIPTION
## Summary
- define an empty theme color palette with color keys

## Testing
- `npx sass --load-path=node_modules/@uswds/uswds/packages src/styles:dist --no-source-map` *(fails: Undefined variable $theme-utilities)*